### PR TITLE
log: cleanup & move much into source/log.cpp

### DIFF
--- a/include/log.hh
+++ b/include/log.hh
@@ -8,122 +8,51 @@
  * @author: Charlie Curtsinger & Tongping Liu
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <atomic>
 
 #include "xdefines.hh"
+
+#define LOG_SIZE 4096
 
 #ifndef DEBUG_LEVEL
 #define DEBUG_LEVEL 0
 #endif
 
-#define NORMAL_CYAN "\033[36m"
-#define NORMAL_MAGENTA "\033[35m"
-#define NORMAL_BLUE "\033[34m"
-#define NORMAL_YELLOW "\033[33m"
-#define NORMAL_GREEN "\033[32m"
-#define NORMAL_RED "\033[31m"
+extern std::atomic_int DT_LOG_LEVEL;
 
-#define BRIGHT_CYAN "\033[1m\033[36m"
-#define BRIGHT_MAGENTA "\033[1m\033[35m"
-#define BRIGHT_BLUE "\033[1m\033[34m"
-#define BRIGHT_YELLOW "\033[1m\033[33m"
-#define BRIGHT_GREEN "\033[1m\033[32m"
-#define BRIGHT_RED "\033[1m\033[31m"
-
-#define ESC_INF NORMAL_CYAN
-#define ESC_DBG NORMAL_GREEN
-#define ESC_WRN BRIGHT_YELLOW
-#define ESC_ERR BRIGHT_RED
-#define ESC_END "\033[0m"
-
-#define OUTFD 2
-#define LOG_SIZE 4096
-
-#define OUTPUT write
-
-#ifndef NDEBUG
-/**
- * Print status-information message: level 0
- */
-#define PRINF(fmt, ...)                                                                            \
-  {                                                                                                \
-    if(DEBUG_LEVEL < 1) {                                                                          \
-      ::snprintf(getThreadBuffer(), LOG_SIZE,                                                      \
-                 ESC_INF "%lx [DOUBLETAKE-INFO]: %20s:%-4d: " fmt ESC_END "\n", pthread_self(),    \
-                 __FILE__, __LINE__, ##__VA_ARGS__);                                               \
-      OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                 \
-    }                                                                                              \
-  }
+namespace doubletake {
+  void logf(const char *file, int line, int level, const char *fmt, ...) __printf_like(4, 5);
+  void fatalf(const char *file, int line, const char *fmt, ...) __printf_like(3, 4) __noreturn;
+  void printf(const char *fmt, ...) __printf_like(1, 2);
+}
 
 /**
  * Print status-information message: level 0
  */
-#define PRDBG(fmt, ...)                                                                            \
+#define _PR(n, ...)                                                                                \
   {                                                                                                \
-    if(DEBUG_LEVEL < 2) {                                                                          \
-      ::snprintf(getThreadBuffer(), LOG_SIZE,                                                      \
-                 ESC_DBG "%lx [DOUBLETAKE-DBG]: %20s:%-4d: " fmt ESC_END "\n", pthread_self(),     \
-                 __FILE__, __LINE__, ##__VA_ARGS__);                                               \
-      OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                 \
-    }                                                                                              \
+    if(DT_LOG_LEVEL.load() < n)                                                                    \
+      doubletake::logf(__FILE__, __LINE__, n, __VA_ARGS__);                                        \
   }
 
-/**
- * Print warning message: level 1
- */
-#define PRWRN(fmt, ...)                                                                            \
-  {                                                                                                \
-    if(DEBUG_LEVEL < 3) {                                                                          \
-      ::snprintf(getThreadBuffer(), LOG_SIZE,                                                      \
-                 ESC_WRN "%lx [DOUBLETAKE-WRN]: %20s:%-4d: " fmt ESC_END "\n", pthread_self(),     \
-                 __FILE__, __LINE__, ##__VA_ARGS__);                                               \
-      OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                 \
-    }                                                                                              \
-  }
+#ifdef NDEBUG
+#define PRINF(...)
+#define PRDBG(...)
+#define PRWRN(...)
 #else
-#define PRINF(fmt, ...)
-#define PRDBG(fmt, ...)
-#define PRWRN(fmt, ...)
-#endif
+#define PRINF(...) _PR(1, __VA_ARGS__)
+#define PRDBG(...) _PR(2, __VA_ARGS__)
+#define PRWRN(...) _PR(3, __VA_ARGS__)
+#endif /* NDEBUG */
 
-/**
- * Print error message: level 2
- */
-#define PRERR(fmt, ...)                                                                            \
-  {                                                                                                \
-    if(DEBUG_LEVEL < 4) {                                                                          \
-      ::snprintf(getThreadBuffer(), LOG_SIZE,                                                      \
-                 ESC_ERR "%lx [DOUBLETAKE-ERR]: %20s:%-4d: " fmt ESC_END "\n", pthread_self(),     \
-                 __FILE__, __LINE__, ##__VA_ARGS__);                                               \
-      OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                 \
-    }                                                                                              \
-  }
+#define PRERR(...) _PR(4, __VA_ARGS__)
 
-// Can't be turned off. But we don't want to output those line number information.
-#define PRINT(fmt, ...)                                                                            \
-  {                                                                                                \
-    ::snprintf(getThreadBuffer(), LOG_SIZE, BRIGHT_MAGENTA fmt ESC_END "\n", ##__VA_ARGS__);       \
-    OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                   \
-  }
-
-/**
- * Print fatal error message, the program is going to exit.
- */
-
-#define FATAL(fmt, ...)                                                                            \
-  {                                                                                                \
-    ::snprintf(getThreadBuffer(), LOG_SIZE,                                                        \
-               ESC_ERR "%lx [DOUBLETAKE-FATALERROR]: %20s:%-4d: " fmt ESC_END "\n",                \
-               pthread_self(), __FILE__, __LINE__, ##__VA_ARGS__);                                 \
-    exit(-1);                                                                                      \
-    OUTPUT(OUTFD, getThreadBuffer(), strlen(getThreadBuffer()));                                   \
-  }
+#define FATAL(...) doubletake::fatalf(__FILE__, __LINE__, __VA_ARGS__)
+#define PRINT(...) doubletake::printf(__VA_ARGS__)
 
 // Check a condition. If false, print an error message and abort
 #define REQUIRE(cond, ...)                                                                         \
-  if(!(cond)) {                                                                                    \
-    FATAL(__VA_ARGS__)                                                                             \
-  }
+  if(!(cond))                                                                                      \
+    FATAL(__VA_ARGS__)
 
 #endif

--- a/include/xdefines.hh
+++ b/include/xdefines.hh
@@ -35,6 +35,9 @@ extern runtime_data_t *global_data;
 #endif
 */
 
+#define __printf_like(a, b) __attribute__((format(printf, a, b)))
+#define __noreturn __attribute__((noreturn))
+
 extern size_t __max_stack_size;
 typedef void* threadFunction(void*);
 extern int getThreadIndex();

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file log.cpp
+ * @brief Log definitions.
+ * @author Bobby Powers
+ */
+
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "log.hh"
+
+#define NORMAL_CYAN "\033[36m"
+#define NORMAL_MAGENTA "\033[35m"
+#define NORMAL_BLUE "\033[34m"
+#define NORMAL_YELLOW "\033[33m"
+#define NORMAL_GREEN "\033[32m"
+#define NORMAL_RED "\033[31m"
+
+#define BRIGHT_CYAN "\033[1m\033[36m"
+#define BRIGHT_MAGENTA "\033[1m\033[35m"
+#define BRIGHT_BLUE "\033[1m\033[34m"
+#define BRIGHT_YELLOW "\033[1m\033[33m"
+#define BRIGHT_GREEN "\033[1m\033[32m"
+#define BRIGHT_RED "\033[1m\033[31m"
+
+#define ESC_INF NORMAL_CYAN
+#define ESC_DBG NORMAL_GREEN
+#define ESC_WRN BRIGHT_YELLOW
+#define ESC_ERR BRIGHT_RED
+#define ESC_END "\033[0m"
+
+#define OUTFD STDERR_FILENO
+
+
+static const char *LEVEL_NAMES[] = {
+  "__bad_level__",
+  "INFO",
+  "DBG",
+  "WRN",
+  "ERR",
+  "FATALERROR"
+};
+static const size_t LEVEL_NAMES_LEN = sizeof(LEVEL_NAMES)/sizeof(*LEVEL_NAMES);
+
+
+// current setting of the global log level - set by default to
+// DEBUG_LEVEL, potentially overridden during library initialization
+std::atomic_int DT_LOG_LEVEL(DEBUG_LEVEL);
+
+#define FMTBUF_LEN 512
+
+
+void doubletake::logf(const char *file, int line, int level, const char *fmt, ...) {
+  char fmtbuf[FMTBUF_LEN];
+  char *tbuf = getThreadBuffer();
+
+  if (level < 1 || (size_t)level >= LEVEL_NAMES_LEN)
+    level = 1;
+  const char *lvl_name = LEVEL_NAMES[level];
+
+  ::snprintf(fmtbuf, FMTBUF_LEN,
+             ESC_INF "%lx [DOUBLETAKE-%s]: %20s:%-4d: %s" ESC_END "\n",
+             pthread_self(), lvl_name, file, line, fmt);
+
+	va_list args;
+
+  va_start(args, fmt);
+  ::vsnprintf(tbuf, LOG_SIZE, fmtbuf, args);
+  va_end(args);
+
+  write(OUTFD, tbuf, strlen(tbuf));
+}
+
+void doubletake::printf(const char *fmt, ...) {
+  char fmtbuf[FMTBUF_LEN];
+  char *tbuf = getThreadBuffer();
+
+  ::snprintf(fmtbuf, FMTBUF_LEN-1, BRIGHT_MAGENTA "%s" ESC_END "\n", fmt);
+
+	va_list args;
+
+  va_start(args, fmt);
+  ::vsnprintf(tbuf, LOG_SIZE, fmtbuf, args);
+  va_end(args);
+
+  write(OUTFD, tbuf, strlen(tbuf));
+}
+
+void doubletake::fatalf(const char *file, int line, const char *fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+  doubletake::logf(file, line, 5, fmt, args);
+  va_end(args);
+
+  exit(-1);
+}

--- a/source/xrun.cpp
+++ b/source/xrun.cpp
@@ -21,7 +21,7 @@
 void xrun::syscallsInitialize() { syscalls::getInstance().initialize(); }
 
 void xrun::rollback() {
-  PRINT("DoubleTake: Activating rollback to isolate error.\n")
+  PRINT("DoubleTake: Activating rollback to isolate error.\n");
   //PRINT("ROLLBACK now!\n");
   // If this is the first time to rollback,
   // then we should rollback now.


### PR DESCRIPTION
Two goals here: support selecting the log-level at runtime (not
yet implemented) without incurring much additional overhead, and
simplify some of the code.

What we're left with is a macro that checks a global atomic
corresponding to the current DoubleTake log-level against the
log-level of the statement (is it a WARNING, INFO, or DEBUG message),
calling into an out-of-line vararg logf function w/ the current file +
line info if we should emit something.

Runtime log-level setting via an environmental variable is something
that will be done as a followup - I think it goes hand in hand with
being able to disable colorized output, to support piping output to a
file or non-terminal.