### PR TITLE
basic multithreading example program + fixes to work on that program

### DIFF
--- a/include/leakcheck.hh
+++ b/include/leakcheck.hh
@@ -44,15 +44,10 @@
 #include "wrappers/stlallocator.h"
 
 class leakcheck {
-
-  leakcheck() {}
-
 public:
-  static leakcheck& getInstance() {
-    static char buf[sizeof(leakcheck)];
-    static leakcheck* theOneTrueObject = new (buf) leakcheck();
-    return *theOneTrueObject;
-  }
+  leakcheck()
+    : _unexploredObjects(), _totalLeakageSize(), _lck(), _sizeList(),
+      _nonStartAddrs(0), _heapBegin(0), _heapEnd(0) {}
 
   void searchHeapPointersInsideGlobals();
 
@@ -291,7 +286,7 @@ private:
 
 #define MAXIMUM_SIZE_POWER 30
   // From 2^4 to 2 ^ 30
-  objectListType _sizeList[30];
+  objectListType _sizeList[MAXIMUM_SIZE_POWER];
 
   // It is used to count how many non-start addresses in
   // the calculation of reachability

--- a/include/threadinfo.hh
+++ b/include/threadinfo.hh
@@ -67,7 +67,7 @@ public:
     // Initialize the backup stacking information.
     size_t perStackSize = __max_stack_size;
 
-    unsigned long totalStackSize = perStackSize * 2 * xdefines::MAX_ALIVE_THREADS;
+    unsigned long totalStackSize = perStackSize * xdefines::MAX_ALIVE_THREADS;
     unsigned long perQbufSize = xdefines::QUARANTINE_BUF_SIZE * sizeof(freeObject);
     unsigned long qbufSize = perQbufSize * xdefines::MAX_ALIVE_THREADS * 2;
 
@@ -82,8 +82,7 @@ public:
 
 			// Those information that are only initialized once.
      	tinfo->available = true;
-     	tinfo->oldContext.setupBackup(&stackStart[perStackSize * 2 * i]);
-      tinfo->newContext.setupBackup(&stackStart[perStackSize * 2 * i + 1]);
+      tinfo->context.setupBackup(&stackStart[perStackSize * i]);
       tinfo->qlist.initialize(&qbufStart[perQbufSize * i * 2], perQbufSize);
     }
 

--- a/include/threadstruct.hh
+++ b/include/threadstruct.hh
@@ -121,12 +121,8 @@ typedef struct thread {
   bool mainThread;
 
   semaphore sema;
-  // We need to keep two context: one is old context, which is saved in the beginning of
-  // transaction. another one is new context, which is normally saved in the signal handler.
-  // For example, if one thread is going to commit, it is going to signal other threads to stop.
-  // so we need another context to save context.
-  xcontext oldContext;
-  xcontext newContext;
+
+  xcontext context;
 
   // The following is the parameter about starting function.
   threadFunction* startRoutine;

--- a/include/xcontext.hh
+++ b/include/xcontext.hh
@@ -18,6 +18,7 @@
  * @brief User context to support the rollback mechanism.
  *
  * @author Tongping Liu <http://www.cs.umass.edu/~tonyliu>
+ * @author Bobby Powers
  */
 
 class xcontext {
@@ -26,267 +27,15 @@ public:
 
   void setupBackup(void* ptr) { _backup = ptr; }
 
-  // void initialize(void * privateStart, void * privateTop, size_t totalPrivateSize, size_t
-  // backupSize)
   void setupStackInfo(void* privateTop, size_t stackSize) {
     _privateTop = privateTop;
     _stackSize = stackSize;
   }
 
-#if 0
-  void rollback (bool stop) {
-    /** There are two steps for this function.
-     * First, we must recover the stack.
-     * Second, we will setcontext to the saved context.
-     * We should be careful about this function:
-     *  a. If the saved stack is equal to or larger than current stack size, 
-     *     then we can't simply overlap current stack from the saved stack.
-     *     since it will screw current stack. 
-     *  b. If the saved stack is smaller than current stacksize, then it can be
-     *     safe to overlap current stack. 
-     * In our implementation, we may utilize a temporary stack to recover the stack.
-     */
-    unsigned long ebp, esp;
-
-    // The offset to the stack bottom.
-    unsigned long espoffset, ebpoffset;
-
-    unsigned long newebp, newesp;
-    unsigned long stackStart;
-    unsigned long offset;
-
-    // Get current esp and ebp
-#if defined(X86_32BIT)
-    asm volatile(
-      "movl %%ebp,%0\n" \
-      "movl %%esp,%1\n" \
-      :"=r"(ebp), "=r"(esp)
-    );
-#else
-    asm volatile(
-      "movq %%rbp,%0\n" \
-      "movq %%rsp, %1\n" \
-      :"=r"(ebp), "=r"(esp)
-    );
-#endif
-
-    // Calculate the offset to stack bottom for ebp and esp register. 
-    // Since we know that we are still using the original stack.
-    espoffset = _stackTop - esp;
-    ebpoffset = _stackTop - ebp;
-
-    // Check whether we can utilize the temporary stack.
-    if(espoffset > xdefines::TEMP_STACK_SIZE) {
-      PRINF("Now esp %lx ebp %lx, stackbottom %lx\n", esp, ebp, _stackTop);
-      PRINF("Now we can't use the reserved temporary stack, espoffset %lx temporary stack size %lx\n", espoffset, xdefines::TEMP_STACK_SIZE);
-      // FIXME: we might use some malloced memory, but not now.
-      abort();
-    }
-
-    // Calculate the new ebp and esp registers. 
-    // We will set ebp to the bottom of temporary stack. 
-    newebp = _tempStackBottom - ebpoffset;
-    newesp = _tempStackBottom - espoffset;
-
-    // Copy the existing stack to the temporary stack.
-    // Otherwise, we can not locate those global variables???
-    memcpy((void *)newesp, (void *)esp, espoffset);
-
-    // Switch the stack manually. 
-    // It is important to switch in this place (not using a function call), otherwise, the lowest
-    // level of frame will be poped out and the stack will return back to the original one
-    // Then techniquely we cann't switch successfully. 
-    // What we want is that new frames are using the new stack, but we will recover
-    // the stack in the same function later to void problems!!!
-#if defined(X86_32BIT)
-    asm volatile(
-      // Set ebp and esp to new pointer
-      "movl %0, %%ebp\n"
-      "movl %1, %%esp\n"
-      : : "r" (newebp), "r" (newesp)
-    );
-#else
-    asm volatile(
-      // Set ebp and esp to new pointer
-      "movq %0,%%rbp\n"
-      "movq %1,%%rsp\n"
-      : : "r" (newebp), "r" (newesp)
-    );
-#endif 
-
-    // The recovery of stack are safe no matter how large of the original stack
-    memcpy(_pstackTopSaved, &_stack, _stackSize);
-    
-    if(stop) {
-      while(1) ;
-    }
-
-    // After recovery of the stack, we can call setcontext to switch to original stack. 
-    setcontext (&_context);
-  }
-#endif
-
-  // Now we need to save the context
-  inline void saveContext() {
-    size_t size;
-    // PRINF("SAVECONTEXT: Current %p _privateTop %p at %p _backup %p\n", getpid(), _privateTop,
-    // &_privateTop, _backup);
-    //    PRINF("saveContext nownow!!!!!!\n");
-    // Save the stack at first.
-    _privateStart = &size;
-    size = size_t((intptr_t)_privateTop - (intptr_t)_privateStart);
-    _backupSize = size;
-
-    if(size >= _stackSize) {
-      PRWRN("Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n", size,
-            _privateTop, _privateStart, _stackSize);
-      Real::exit(-1);
-    }
-    memcpy(_backup, _privateStart, size);
-    // We are trying to save context at first
-    getcontext(&_context);
-  }
-
-  // We already have context. How we can save this context.
-  inline void saveSpecifiedContext(ucontext_t* context) {
-    // Find out the esp pointer.
-    size_t size;
-
-    // Save the stack at first.
-    _privateStart = (void*)getStackPointer(context);
-    size = size_t((intptr_t)_privateTop - (intptr_t)_privateStart);
-    _backupSize = size;
-
-    if(size >= _stackSize) {
-      PRWRN("Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n", size,
-            _privateTop, _privateStart, _stackSize);
-      abort();
-    }
-
-    memcpy(_backup, _privateStart, size);
-
-    // We are trying to save context at first
-    memcpy(&_context, context, sizeof(ucontext_t));
-  }
-
-  /* Finish the following tasks here:
-    a. Change current stack to the stack of newContext. We have to utilize
-       a temporary stack to host current stack.
-    b. Copy the stack from newContext to current stack.
-    c. Switch back from the temporary stack to current stack.
-    d. Copy the stack and context from newContext to oldContext.
-    f. setcontext to the context of newContext.
-   */
-  inline static void resetContexts(xcontext* oldContext, xcontext* newContext) {
-    // We can only do this when these two contexts are for the same thread.
-    assert(oldContext->getPrivateTop() == newContext->getPrivateTop());
-
-    // We will backup the stack and context from newContext at first.
-    oldContext->backupStackAndContext(newContext);
-
-    restoreContext(oldContext, newContext);
-  }
-
-  // Copy the stack from newContext to oldContext.
-  void backupStackAndContext(xcontext* context) {
-    // We first backup the context.
-    _privateStart = context->getPrivateStart();
-    _backupSize = context->getBackupSize();
-
-    memcpy(_backup, context->getBackupStart(), _backupSize);
-
-    // Now we will backup the context.
-    memcpy(&_context, context->getContext(), sizeof(ucontext_t));
-  }
-
-  static void rollbackInsideSignalHandler(ucontext_t* context, xcontext* oldContext) {
-    // We first rollback the stack.
-		// Since the thread is inside the context of signal handler, we can simply 
-		// recover the stack by copying, no need to worry about the correctness
-    memcpy(oldContext->getPrivateStart(), oldContext->getBackupStart(),
-           oldContext->getBackupSize());
-
-    memcpy(context, oldContext->getContext(), sizeof(ucontext_t));
-  }
-
-  // Restore context from specified context.
-  /* Finish the following tasks here:
-    a. Change current stack to the stack of newContext. We have to utilize
-       a temporary stack to host current stack.
-    b. Copy the stack from current context to current stack.
-    c. setcontext to the context of newContext.
-   */
-  inline static void restoreContext(xcontext* oldContext, xcontext* newContext) {
-    // We can only do this when these two contexts are for the same thread.
-    assert(oldContext->getPrivateTop() == newContext->getPrivateTop());
-
-    // Now we can mess with newContext.
-    unsigned long ebp, esp;
-
-    // The offset to the stack bottom.
-    unsigned long espoffset, ebpoffset;
-    unsigned long stackTop, newStackTop;
-    unsigned long newebp, newesp;
-// Get current esp and ebp
-#if defined(X86_32BIT)
-    asm volatile("movl %%ebp,%0\n"
-                 "movl %%esp,%1\n"
-                 : "=r"(ebp), "=r"(esp));
-#else
-    asm volatile("movq %%rbp,%0\n"
-                 "movq %%rsp, %1\n"
-                 : "=r"(ebp), "=r"(esp));
-#endif
-
-    // Calculate the offset to stack bottom for ebp and esp register.
-    // Since we know that we are still using the original stack.
-    stackTop = (unsigned long)newContext->getPrivateTop();
-    espoffset = stackTop - esp;
-    ebpoffset = stackTop - ebp;
-
-    REQUIRE(espoffset <= xdefines::TEMP_STACK_SIZE, "Temporary stack exhausted");
-
-    // Calculate the new ebp and esp registers.
-    // We will set ebp to the bottom of temporary stack.
-    newStackTop = (intptr_t)newContext->getBackupStart() + newContext->getStackSize();
-    newebp = newStackTop - ebpoffset;
-    newesp = newStackTop - espoffset;
-
-    // Copy the existing stack to the temporary stack.
-    // Otherwise, we can not locate those global variables???
-    memcpy((void*)newesp, (void*)esp, espoffset);
-
-// Switch the stack manually.
-// It is important to switch in this place (not using a function call), otherwise, the lowest
-// level of frame will be poped out and the stack will return back to the original one
-// Then techniquely we cann't switch successfully.
-// What we want is that new frames are using the new stack, but we will recover
-// the stack in the same function later to void problems!!!
-#if defined(X86_32BIT)
-    asm volatile(
-        // Set ebp and esp to new pointer
-        "movl %0, %%ebp\n"
-        "movl %1, %%esp\n"
-        :
-        : "r"(newebp), "r"(newesp));
-#else
-    asm volatile(
-        // Set ebp and esp to new pointer
-        "movq %0,%%rbp\n"
-        "movq %1,%%rsp\n"
-        :
-        : "r"(newebp), "r"(newesp));
-#endif
-
-    // PRINF("________RESTORECONTEX___________at line %d\n", __LINE__);
-    // Now we will recover the stack from the saved oldContext.
-    memcpy(oldContext->getPrivateStart(), oldContext->getBackupStart(),
-           oldContext->getBackupSize());
-
-    PRINF("Thread %p is calling actual setcontext", (void*)pthread_self());
-    // After recovery of the stack, we can call setcontext to switch to original stack.
-    setcontext(oldContext->getContext());
-  }
+  void saveCurrent();
+  void save(ucontext_t *context);
+  void rollback();
+  void rollbackInHandler(ucontext_t *context);
 
   void* getStackTop() { return _privateTop; }
 
@@ -294,26 +43,15 @@ private:
   ucontext_t* getContext() { return &_context; }
 
   void* getPrivateStart() { return _privateStart; }
-
   void* getPrivateTop() { return _privateTop; }
-
   size_t getBackupSize() { return _backupSize; }
-
   size_t getStackSize() { return _stackSize; }
-
   void* getBackupStart() { return _backup; }
-  // How to get ESP/RSP from the specified context.
-  unsigned long getStackPointer(ucontext* context) {
-#ifndef X86_32BIT
-    return context->uc_mcontext.gregs[REG_RSP];
-#else
-    return context->uc_mcontext.gregs[REG_ESP];
-#endif
-  }
 
-  /// The saved registers, etc.
+  /// Saved registers, including the IP, SP, general purpose and floating point.
   ucontext_t _context;
-  void* _backup; // Where to _backup those thread private information.
+
+  void* _backup; // Where to _backup the thread private information.
   void* _privateStart;
   void* _privateTop;
   size_t _stackSize;

--- a/include/xdefines.hh
+++ b/include/xdefines.hh
@@ -49,7 +49,7 @@ extern runtime_data_t *global_data;
 extern size_t __max_stack_size;
 typedef void* threadFunction(void*);
 extern int getThreadIndex();
-extern char* getThreadBuffer();
+extern char* getCurrentThreadBuffer();
 extern void jumpToFunction(ucontext_t* cxt, unsigned long funcaddr);
 extern bool addThreadQuarantineList(void* ptr, size_t size);
 

--- a/include/xdefines.hh
+++ b/include/xdefines.hh
@@ -6,8 +6,10 @@
 
 #ifdef X86_32BIT
 #define REG_IP REG_EIP
+#define REG_SP REG_ESP
 #else
 #define REG_IP REG_RIP
+#define REG_SP REG_RSP
 #endif
 
 #include "list.hh"

--- a/include/xrun.hh
+++ b/include/xrun.hh
@@ -126,6 +126,9 @@ public:
   void epochBegin();
   void epochEnd(bool endOfProgram);
 
+  int getThreadIndex() const { return _thread.getThreadIndex(); }
+  char *getCurrentThreadBuffer() { return _thread.getCurrentThreadBuffer(); }
+
 private:
   void syscallsInitialize();
   void stopAllThreads();

--- a/include/xsync.hh
+++ b/include/xsync.hh
@@ -120,14 +120,7 @@ private:
 	};
 
 public:
-  xsync() {}
-
-	static xsync& getInstance() {
-    static char buf[sizeof(xsync)];
-    static xsync* theOneTrueObject = new (buf) xsync();
-    return *theOneTrueObject;
-  }
-
+  explicit xsync() {}
 
   void initialize() {
 		// Initialize two lists for record synchronization variables.
@@ -190,12 +183,8 @@ public:
 		lock();
 		entry =  _newList.retrieveSyncEntry(type, nominal);
 		unlock();
-		if(entry != NULL) {
-			return entry->real;
-		}
-		else {
-			return NULL;
-		}	
+
+		return entry->real;
 	}
 
 	// During the begin of an epoch
@@ -308,7 +297,7 @@ public:
 
 		// Having pending events
     if(!isListEmpty(eventlist)) {
-		PRINF("During peek, calling singalCurrentThread %d. with pending events.\n", thread->index);
+		PRINF("During peek, calling singalCurrentThread %d. with pending events.", thread->index);
       // Signal itself when current event is first event of this thread.
       struct pendingSyncEvent* pe = NULL;
 
@@ -419,7 +408,7 @@ public:
   static void prepareEventListRollback(SyncEventList* eventlist) {
     struct syncEvent* event = eventlist->prepareRollback();
 
-		PRINF("prepareEventListRollback eventlist %p event %p\n", eventlist, event);
+		PRINF("prepareEventListRollback eventlist %p event %p", eventlist, event);
     if(event) {
       // Signal to next thread with the top event
       signalNextThread(event);

--- a/include/xthread.hh
+++ b/include/xthread.hh
@@ -49,7 +49,7 @@ class xthread {
 	};
 
 public:
-  xthread() : _sync(xsync::getInstance()),
+  xthread() : _sync(),
 							_thread(threadinfo::getInstance())
 	{}
 
@@ -1088,7 +1088,7 @@ private:
 
   // Insert a synchronization variable into the global list, which
   // are reaped later in the beginning of next epoch.
-  inline static bool deferSync(void* ptr, syncVariableType type) {
+  inline bool deferSync(void* ptr, syncVariableType type) {
 		if(type == E_SYNCVAR_THREAD) {
     	return threadinfo::getInstance().deferSync(ptr, type);
 		}
@@ -1098,7 +1098,7 @@ private:
 			//if(type == E_SYNCVAR_BARRIER) {
 			//	PRINF("Barrier before detroy ptr %p entry %p\n", ptr, entry);
 			//}
-			xsync::getInstance().deferSync(entry);
+			_sync.deferSync(entry);
 			return true;
 		}
   }
@@ -1178,7 +1178,7 @@ private:
 
   // They are claimed in xthread.cpp since I don't
   // want to create an xthread.cpp
-  xsync& _sync;
+  xsync _sync;
 	SysRecord _sysrecord;
   threadinfo& _thread;
   SyncEventList * _spawningList;

--- a/include/xthread.hh
+++ b/include/xthread.hh
@@ -49,9 +49,7 @@ class xthread {
 	};
 
 public:
-  xthread() : _sync(),
-							_thread(threadinfo::getInstance())
-	{}
+  xthread() : _sync(), _sysrecord(), _thread() {}
 
   // Actually, it is not an actual singleton.
   // Every process will have one copy. They can be used
@@ -82,6 +80,9 @@ public:
   void finalize() {
 		destroyAllSemaphores(); 
 	}
+
+  int getThreadIndex() const;
+  char *getCurrentThreadBuffer();
 
   // After an epoch is end and there is no overflow,
   // we should discard those record events since there is no
@@ -334,7 +335,7 @@ public:
     invokeCommit();
     retval = Real::pthread_cancel(thread);
     if(retval == 0) {
-      threadinfo::getInstance().cancelAliveThread(thread);
+      _thread.cancelAliveThread(thread);
     }
     return retval;
   }
@@ -406,10 +407,9 @@ public:
       	list->recordSyncEvent(E_SYNC_MUTEX_LOCK, ret);
      		PRINF("Thread %d recording: mutex_lock at mutex %p realMutex %p list %p\n", current->index, mutex, realMutex, list);
 			}
-    } 
-		else if (!current->disablecheck) {
+    } else if (!current->disablecheck) {
       // PRINF("synceventlist get mutex at %p list %p\n", mutex, list);
-     PRINF("REPLAY: Thread %d: mutex_lock at mutex %p list %p.\n", current->index, mutex, list);
+      PRINF("REPLAY: Thread %d: mutex_lock at mutex %p list %p.\n", current->index, mutex, list);
       assert(list != NULL);
 
 			/* Peek the synchronization event (first event in the thread), it will confirm the following things
@@ -434,9 +434,19 @@ public:
     return ret;
   }
 
-  int mutex_lock(pthread_mutex_t* mutex) { return do_mutex_lock(mutex, E_SYNC_MUTEX_LOCK); }
+  int mutex_lock(pthread_mutex_t* mutex) {
+    if (current->disablecheck)
+      return Real::pthread_mutex_lock((pthread_mutex_t *)mutex);
+    else
+      return do_mutex_lock(mutex, E_SYNC_MUTEX_LOCK);
+  }
 
-  int mutex_trylock(pthread_mutex_t* mutex) { return do_mutex_lock(mutex, E_SYNC_MUTEX_TRY_LOCK); }
+  int mutex_trylock(pthread_mutex_t* mutex) {
+    if (current->disablecheck)
+      return Real::pthread_mutex_trylock((pthread_mutex_t *)mutex);
+    else
+      return do_mutex_lock(mutex, E_SYNC_MUTEX_TRY_LOCK);
+  }
 
   int mutex_unlock(pthread_mutex_t* mutex) {
     int ret = 0;
@@ -448,8 +458,7 @@ public:
 
 			// Now the thread is safe to be interrupted.
   		setThreadSafe();
-    } 
-		else if(!current->disablecheck) {
+    } else if(!current->disablecheck) {
       SyncEventList* list = getSyncEventList(mutex, sizeof(pthread_mutex_t));
       PRDBG("mutex_unlock at mutex %p list %p\n", mutex, list);
       //	PRINF("mutex_unlock at mutex %p list %p\n", mutex, list);
@@ -458,6 +467,8 @@ public:
         _sync.signalNextThread(nextEvent);
       }
       PRDBG("mutex_unlock at mutex %p list %p done\n", mutex, list);
+    } else {
+      Real::pthread_mutex_unlock(mutex);
     }
     // WARN("mutex_unlock mutex %p\n", mutex);
     return ret;
@@ -852,7 +863,7 @@ public:
   };
 
   inline static void restoreContext() {
-    PRINF("restore context now\n");
+    PRINF("restore context now (ROLLBACK)");
     current->context.rollback();
   };
 
@@ -866,10 +877,10 @@ public:
   inline static void rollbackContext() { assert(0); }
 
   // Run those deferred synchronization.
-  inline static void runDeferredSyncs() { threadinfo::getInstance().runDeferredSyncs(); }
+  inline void runDeferredSyncs() { _thread.runDeferredSyncs(); }
 
   //
-  inline static bool hasReapableThreads() { return threadinfo::getInstance().hasReapableThreads(); }
+  inline bool hasReapableThreads() { return _thread.hasReapableThreads(); }
 
   inline static void enableCheck() {
     current->internalheap = false;
@@ -902,8 +913,7 @@ private:
 			void * real = _sync.retrieveRealSyncEntry(type, nominal);
 			if(real != NULL) {
 				*((void **)nominal) = real;
-			}
-			else if(type == E_SYNCVAR_MUTEX) {
+			} else if(type == E_SYNCVAR_MUTEX) {
 				// Somehow, replay phase may call different lock, for example, backtrace.
 				// Allocate an real entry for that.
       	// Allocate a mutex
@@ -970,9 +980,9 @@ private:
   static void waitSemaphore() {
     semaphore* sema = &current->sema;
 
-		PRINF("wait on semaphore %p\n", sema);
+		PRINF("wait on semaphore %p", sema);
     sema->get();
-		PRINF("Get the semaphore %p\n", sema);
+		PRINF("Get the semaphore %p", sema);
   }
 
   semaphore* getSemaphore() { return &current->sema; }
@@ -1089,10 +1099,9 @@ private:
   // Insert a synchronization variable into the global list, which
   // are reaped later in the beginning of next epoch.
   inline bool deferSync(void* ptr, syncVariableType type) {
-		if(type == E_SYNCVAR_THREAD) {
-    	return threadinfo::getInstance().deferSync(ptr, type);
-		}
-		else {
+    if(type == E_SYNCVAR_THREAD) {
+      return _thread.deferSync(ptr, type);
+    } else {
 			xsync::SyncEntry * entry = (xsync::SyncEntry *)(*((void **)((intptr_t)ptr + sizeof(void *))));
 
 			//if(type == E_SYNCVAR_BARRIER) {
@@ -1176,11 +1185,9 @@ private:
     return result;
   }
 
-  // They are claimed in xthread.cpp since I don't
-  // want to create an xthread.cpp
   xsync _sync;
-	SysRecord _sysrecord;
-  threadinfo& _thread;
+  SysRecord _sysrecord;
+  threadinfo _thread;
   SyncEventList * _spawningList;
 };
 

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -55,7 +55,7 @@ std::atomic_int DT_LOG_LEVEL(DEBUG_LEVEL);
 
 void doubletake::logf(const char *file, int line, int level, const char *fmt, ...) {
   char fmtbuf[FMTBUF_LEN];
-  char *tbuf = getThreadBuffer();
+  char *tbuf = getCurrentThreadBuffer();
 
   if (level < 1 || (size_t)level >= LEVEL_NAMES_LEN)
     level = 1;
@@ -76,7 +76,7 @@ void doubletake::logf(const char *file, int line, int level, const char *fmt, ..
 
 void doubletake::printf(const char *fmt, ...) {
   char fmtbuf[FMTBUF_LEN];
-  char *tbuf = getThreadBuffer();
+  char *tbuf = getCurrentThreadBuffer();
 
   ::snprintf(fmtbuf, FMTBUF_LEN-1, BRIGHT_MAGENTA "%s" ESC_END "\n", fmt);
 

--- a/source/memtrack.cpp
+++ b/source/memtrack.cpp
@@ -1,4 +1,7 @@
+#include <execinfo.h>
+
 #include "memtrack.hh"
+#include "xthread.hh"
 
 #include "selfmap.hh"
 #include "sentinelmap.hh"
@@ -26,7 +29,9 @@ void memtrack::check(void* start, size_t size, memTrackType type) {
        (object->hasLeak() && (object->objectSize == size))) {
       // Now we check the type of this object.
       void* callsites[xdefines::CALLSITE_MAXIMUM_LENGTH];
-      int depth = selfmap::getCallStack((void**)&callsites);
+      xthread::disableCheck();
+      int depth = backtrace(callsites, xdefines::CALLSITE_MAXIMUM_LENGTH);
+      xthread::enableCheck();
       object->saveCallsite(size, type, depth, (void**)&callsites[0]);
 #ifndef EVALUATING_PERF
 			// Since printing can cause SPEC2006 benchmarks to fail, thus comment them for evaluating perf.

--- a/source/rollback_amd64.s
+++ b/source/rollback_amd64.s
@@ -1,0 +1,40 @@
+.globl __dt_rollback_ctx
+.type __dt_rollback_ctx,@function
+__dt_rollback_ctx:
+	push %rbp
+	mov %rsp, %rbp
+
+	// hold onto 4th arg (ucontext_t *)
+	mov %rcx, %r8
+
+	// musl's memcpy - after this sequence the stack has been
+	// restored but the current values of RBP and RSP may point
+	// into the middle of this region - they MUST be restored by us.
+	mov %rdi,%rax
+	cmp $8,%rdx
+	jc 1f
+	test $7,%edi
+	jz 1f
+2:	movsb
+	dec %rdx
+	test $7,%edi
+	jnz 2b
+1:	mov %rdx,%rcx
+	shr $3,%rcx
+	rep
+	movsq
+	and $7,%edx
+	jz 1f
+2:	movsb
+	dec %edx
+	jnz 2b
+
+	// restore the stack + base pointers - we can't simply jmp
+	// to setcontext (to avoid the call instruction pushing rip
+	// onto the stack) as setcontext requires the stack itself.
+1:	mov 160(%r8), %rsp // (ucontext_t *)->uc_mcontext.gregs[REG_RSP]
+	mov 120(%r8), %rbp // (ucontext_t *)->uc_mcontext.gregs[REG_RBP]
+
+	// now call setcontext with the (ucontext_t *) as its only arg
+	mov %r8, %rdi
+	callq setcontext@PLT

--- a/source/xcontext.cpp
+++ b/source/xcontext.cpp
@@ -1,0 +1,95 @@
+/**
+ * @class xcontext
+ * @brief User context to support the rollback mechanism.
+ *
+ * @author Tongping Liu <http://www.cs.umass.edu/~tonyliu>
+ */
+
+#include "xcontext.hh"
+
+// these functions are defined in assembly so that they can safely
+// swap the stack underneath themselves
+extern "C" {
+  void __dt_rollback_ctx(void *dst, void *src, size_t len, ucontext_t *ctx);
+}
+
+#define PAGE_SIZE 4096
+#define PAGE_MASK (PAGE_SIZE-1)
+#define PAGE_ALIGN(x) (((intptr_t)(x) + (intptr_t)(PAGE_MASK)) & ~PAGE_MASK)
+#define PAGE_ALIGN_DOWN(x) PAGE_ALIGN(x) - PAGE_SIZE
+
+static intptr_t getStackPointer(ucontext* uctx) {
+  return uctx->uc_mcontext.gregs[REG_SP];
+}
+
+void xcontext::save(ucontext_t *uctx) {
+  intptr_t sp;
+  intptr_t stackBottom;
+  size_t size;
+
+  sp = getStackPointer(uctx);
+  stackBottom = PAGE_ALIGN_DOWN(sp);
+
+  _privateStart = (void *)stackBottom;
+  size = (intptr_t)_privateTop - stackBottom;
+  _backupSize = size;
+
+  REQUIRE(size < _stackSize,
+          "Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n",
+          size, _privateTop, _privateStart, _stackSize);
+
+  memcpy(_backup, _privateStart, size);
+
+  // We are trying to save context at first
+  memcpy(&_context, uctx, sizeof(ucontext_t));
+}
+
+void xcontext::saveCurrent() {
+  intptr_t sp;
+  intptr_t stackBottom;
+  size_t size;
+
+#if defined(X86_32BIT)
+  asm volatile(
+    // directly grab esp
+    "movl %%esp, %0\n"
+    : "=r"(sp));
+#else
+  asm volatile(
+    // directly grab rsp
+    "movq %%rsp, %0\n"
+    : "=r"(sp));
+#endif
+
+  stackBottom = PAGE_ALIGN_DOWN(sp);
+
+  _privateStart = (void *)stackBottom;
+  size = (intptr_t)_privateTop - stackBottom;
+  _backupSize = size;
+
+  PRINF("Backup size: %zu/%zu", size, _stackSize);
+
+  REQUIRE(size < _stackSize,
+          "Stack too large. top:%p sp:%p PAGE_ALIGN(sp):%p size:%zu",
+          _privateTop, (void *)sp, (void *)stackBottom, size);
+
+  memcpy(_backup, _privateStart, size);
+  getcontext(&_context);
+}
+
+void xcontext::rollback() {
+  // call an arch-specific routine to safely copy the stack under us
+  // (requires memcpy w/o using the stack, something I don't think we
+  // can guarantee in C) and call setcontext
+  __dt_rollback_ctx(_privateStart, _backup, _backupSize, &_context);
+}
+
+// perform a rollback while in the signal handler - this ucontext_t is
+// passed back to the kernel on return from the signal handler and
+// execution resumes there.  Additionally, SIGUSR2 is masked while the
+// handler is running so we don't have to worry about receiving a
+// signal in the middle of this method.
+void xcontext::rollbackInHandler(ucontext_t* kctx) {
+  memcpy(_privateStart, _backup, _backupSize);
+  memcpy(kctx, &_context, sizeof(_context));
+}

--- a/source/xrun.cpp
+++ b/source/xrun.cpp
@@ -262,8 +262,8 @@ void jumpToFunction(ucontext_t* cxt, unsigned long funcaddr) {
 
   // Check what is the current phase
   if(global_isEpochBegin()) {
- 		// Current thread is going to enter a new phase
-    xthread::getInstance().saveSpecifiedContext((ucontext_t*)context);
+    // Current thread is going to enter a new phase
+    xthread::getInstance().saveContext((ucontext_t*)context);
     // NOTE: we do not need to reset contexts if we are still inside the signal handleer
     // since the exiting from signal handler can do this automatically.
   } else {

--- a/source/xrun.cpp
+++ b/source/xrun.cpp
@@ -17,6 +17,14 @@
 #include "threadmap.hh"
 #include "threadstruct.hh"
 
+int getThreadIndex() {
+  return xrun::getInstance().getThreadIndex();
+}
+
+char *getCurrentThreadBuffer() {
+  return xrun::getInstance().getCurrentThreadBuffer();
+}
+
 void xrun::syscallsInitialize() { syscalls::getInstance().initialize(); }
 
 void xrun::rollback() {
@@ -80,7 +88,7 @@ void xrun::epochBegin() {
   }
   PRINF("xrun epochBegin, joinning every thread done.\n");
 
-  xthread::runDeferredSyncs();
+  _thread.runDeferredSyncs();
 
   PRINF("xrun epochBegin, run deferred synchronizations done.\n");
 

--- a/source/xthread.cpp
+++ b/source/xthread.cpp
@@ -29,7 +29,7 @@ __thread thread_t* current;
 // threadmap::threadHashMap threadmap::_xmap;
 list_t threadmap::_alivethreads;
 
-int getThreadIndex() {
+int xthread::getThreadIndex() const {
   if(!global_isInitPhase()) {
     return current->index;
   } else {
@@ -37,10 +37,10 @@ int getThreadIndex() {
   }
 }
 
-char* getThreadBuffer() {
+char* xthread::getCurrentThreadBuffer() {
   int index = getThreadIndex();
 
-  return threadinfo::getInstance().getThreadBuffer(index);
+  return _thread.getThreadBuffer(index);
 }
 
 void xthread::invokeCommit() {

--- a/tests/build.mk
+++ b/tests/build.mk
@@ -6,7 +6,7 @@ TEST_BIN_TARGETS += $(SIMPLE_TARGETS)
 TESTS            += simple-tests
 
 SIMPLE_TARGETS   := $(addprefix $(DIR)/, $(addsuffix /simple.test, $(SIMPLE_TESTS)))
-SIMPLE_LDFLAGS   += -L. -ldoubletake -lpthread
+SIMPLE_LDFLAGS   += -L. -lpthread
 
 # no optimization - clang is smart enough to see in the 'use after
 # free' test that the object is allocated, referenced, freed, and
@@ -20,8 +20,8 @@ SIMPLE_LDFLAGS   += -L. -ldoubletake -lpthread
 
 $(SIMPLE_TESTS): $(SIMPLE_TARGETS)
 	@echo "  TEST  $@"
-#	LD_PRELOAD=./libdoubletake.so tests/$@/simple.test
-	LD_LIBRARY_PATH=. tests/$@/simple.test
+	LD_PRELOAD=./libdoubletake.so tests/$@/simple.test
+#	LD_LIBRARY_PATH=. tests/$@/simple.test
 
 simple-tests: $(SIMPLE_TESTS)
 

--- a/tests/build.mk
+++ b/tests/build.mk
@@ -1,12 +1,12 @@
 DIR              := tests
 
-SIMPLE_TESTS     := simple_leak simple_overflow simple_uaf
+SIMPLE_TESTS     := simple_leak simple_overflow simple_uaf simple_mt_uaf
 
 TEST_BIN_TARGETS += $(SIMPLE_TARGETS)
 TESTS            += simple-tests
 
 SIMPLE_TARGETS   := $(addprefix $(DIR)/, $(addsuffix /simple.test, $(SIMPLE_TESTS)))
-SIMPLE_LDFLAGS   += -L. -lpthread -ldoubletake
+SIMPLE_LDFLAGS   += -L. -ldoubletake -lpthread
 
 # no optimization - clang is smart enough to see in the 'use after
 # free' test that the object is allocated, referenced, freed, and

--- a/tests/simple_mt_uaf/main.c
+++ b/tests/simple_mt_uaf/main.c
@@ -1,0 +1,131 @@
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+    This program performs the following sequence of events:
+
+    thread 1            thread 2
+     (main)           (worker_main)
+
+    pthread_create                
+    malloc(array)                 
+
+                      write(array)
+                      free(array)
+
+    write(array)
+
+                      pthread_exit
+
+    pthread_join
+    exit
+
+    This order-of-events is enforced through atomic reads + writes of
+    a global sequence number, avoiding unspecified behavior as well as
+    the use of mutexes, so that we don't trigger any intermediate
+    epoch expirations.
+
+    This is a classic use-after-free, and is properly identified as
+    such by valgrind:
+
+    ==15506== Invalid write of size 1
+    ==15506==    at 0x4008B5: main (main.c:122)
+    ==15506==  Address 0x53ed040 is 0 bytes inside a block of size 255 free'd
+    ==15506==    at 0x4C2B1F0: free (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
+    ==15506==    by 0x400794: worker_main (main.c:86)
+    ==15506==    by 0x4E3D333: start_thread (pthread_create.c:333)
+
+    As well as tsan:
+
+    ==================
+    WARNING: ThreadSanitizer: heap-use-after-free (pid=16214)
+      Write of size 1 at 0x7d4000007f00 by main thread:
+        #0 main /home/bpowers/plasma/DoubleTake/test/simple_mt_uaf/main.c:122:2 (simple.test+0x0000004b86a3)
+
+        n  Previous write of size 8 at 0x7d4000007f00 by thread T1:
+        #0 free /var/tmp/portage/sys-devel/llvm-3.6.2/work/llvm-3.6.2.src/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:538:3 (simple.test+0x00000045267b)
+        #1 worker_main /home/bpowers/plasma/DoubleTake/test/simple_mt_uaf/main.c:86:2 (simple.test+0x0000004b846c)
+
+      Thread T1 (tid=16216, running) created by main thread at:
+        #0 pthread_create /var/tmp/portage/sys-devel/llvm-3.6.2/work/llvm-3.6.2.src/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:896:3 (simple.test+0x000000455f51)
+        #1 main /home/bpowers/plasma/DoubleTake/test/simple_mt_uaf/main.c:107:2 (simple.test+0x0000004b85bb)
+
+    SUMMARY: ThreadSanitizer: heap-use-after-free /home/bpowers/plasma/DoubleTake/test/simple_mt_uaf/main.c:122 main
+    ==================
+    ThreadSanitizer: reported 1 warnings
+*/
+
+#define ARRAY_SIZE   0xff
+
+// sequence number - use this to coordinate memory operation orders
+// without mutexes (so that coordination between threads doesn't
+// trigger epoch expirations)
+atomic_int       g_seq;
+atomic_uintptr_t g_array;
+
+// release the cacheline on the variable we're waiting for
+static inline void spin() {
+	__asm__ __volatile__("pause" : : : "memory");
+}
+
+void *
+worker_main(void *arg) {
+	char n = (char)(uintptr_t)arg;
+
+	// wait for the main thread to store the dynamically allocated
+	// array in g_array
+	while (atomic_load_explicit(&g_seq, memory_order_acquire) != 1)
+		spin();
+
+	// get the location of the array, write to it, and free it.
+	char *array = (char *)atomic_load(&g_array);
+	for (size_t i = 0; i < ARRAY_SIZE; i++)
+		array[i] = n;
+	free(array);
+
+	// inform the main thread that we have free'd the array
+	atomic_store_explicit(&g_seq, 2, memory_order_release);
+
+	// wait for main thread to perform a use-after-free before we exit
+	while (atomic_load_explicit(&g_seq, memory_order_acquire) != 3)
+		spin();
+
+	//pthread_exit(NULL);
+	return NULL;
+}
+
+int
+main(int argc, const char *argv[]) {
+	pthread_t worker;
+
+	char *array = calloc(ARRAY_SIZE, sizeof(*array));
+	if (!array)
+		return -1;
+
+	pthread_create(&worker, NULL, worker_main, (void *)0x11);
+
+	// pass the array to the worker thread, and increase the
+	// sequence number, allowing the worker to progress into the
+	// 'write + free' phase.
+	atomic_thread_fence(memory_order_seq_cst);
+	atomic_store(&g_array, (uintptr_t)array);
+	atomic_store(&g_seq, 1);
+
+	// wait for the worker to free the array
+	while (atomic_load_explicit(&g_seq, memory_order_acquire) != 2)
+		spin();
+
+	// at this point, the array has been free'd in the worker
+	// thread - perform a use-after-free
+	array[0] = 0;
+
+	// tell the worker it can exit
+	atomic_store(&g_seq, 3);
+
+	// wait for the worker to exit
+	pthread_join(worker, NULL);
+
+	return 0;
+}


### PR DESCRIPTION
This introduces a simple program that allocates memory on one thread, frees it on another, and then uses it after being freed on the first thread.  Also included are fixes to DoubleTake to not crash when run on this program. 

```
  TEST  simple_mt_uaf
  DoubleTake: Use-after-free error detected at address 0x100000020.
  DoubleTake: Activating rollback to isolate error.

DoubleTake: checking 0 point: address 0x100000020 currentvalue 0 value 0

DoubleTake: checking 0 point: address 0x100000020 currentvalue 0 value cafebabecafeba00

Caught a use-after-free error at 0x100000020. Current call stack:

0x0000000000400971: /home/bpowers/plasma/DoubleTake/tests/simple_mt_uaf/main.c:122
0x00000000004006c8: ??:?
0x00000000004008ce: /home/bpowers/plasma/DoubleTake/tests/simple_mt_uaf/main.c:103
Memory deallocation call stack:

0x000000000040084f: /home/bpowers/plasma/DoubleTake/tests/simple_mt_uaf/main.c:86
```