### PR TITLE
xcontext: simplify context save + restore

### DIFF
--- a/include/threadinfo.hh
+++ b/include/threadinfo.hh
@@ -67,7 +67,7 @@ public:
     // Initialize the backup stacking information.
     size_t perStackSize = __max_stack_size;
 
-    unsigned long totalStackSize = perStackSize * 2 * xdefines::MAX_ALIVE_THREADS;
+    unsigned long totalStackSize = perStackSize * xdefines::MAX_ALIVE_THREADS;
     unsigned long perQbufSize = xdefines::QUARANTINE_BUF_SIZE * sizeof(freeObject);
     unsigned long qbufSize = perQbufSize * xdefines::MAX_ALIVE_THREADS * 2;
 
@@ -82,8 +82,7 @@ public:
 
 			// Those information that are only initialized once.
      	tinfo->available = true;
-     	tinfo->oldContext.setupBackup(&stackStart[perStackSize * 2 * i]);
-      tinfo->newContext.setupBackup(&stackStart[perStackSize * 2 * i + 1]);
+      tinfo->context.setupBackup(&stackStart[perStackSize * i]);
       tinfo->qlist.initialize(&qbufStart[perQbufSize * i * 2], perQbufSize);
     }
 

--- a/include/threadstruct.hh
+++ b/include/threadstruct.hh
@@ -121,12 +121,8 @@ typedef struct thread {
   bool mainThread;
 
   semaphore sema;
-  // We need to keep two context: one is old context, which is saved in the beginning of
-  // transaction. another one is new context, which is normally saved in the signal handler.
-  // For example, if one thread is going to commit, it is going to signal other threads to stop.
-  // so we need another context to save context.
-  xcontext oldContext;
-  xcontext newContext;
+
+  xcontext context;
 
   // The following is the parameter about starting function.
   threadFunction* startRoutine;

--- a/include/xcontext.hh
+++ b/include/xcontext.hh
@@ -18,6 +18,7 @@
  * @brief User context to support the rollback mechanism.
  *
  * @author Tongping Liu <http://www.cs.umass.edu/~tonyliu>
+ * @author Bobby Powers
  */
 
 class xcontext {
@@ -26,267 +27,15 @@ public:
 
   void setupBackup(void* ptr) { _backup = ptr; }
 
-  // void initialize(void * privateStart, void * privateTop, size_t totalPrivateSize, size_t
-  // backupSize)
   void setupStackInfo(void* privateTop, size_t stackSize) {
     _privateTop = privateTop;
     _stackSize = stackSize;
   }
 
-#if 0
-  void rollback (bool stop) {
-    /** There are two steps for this function.
-     * First, we must recover the stack.
-     * Second, we will setcontext to the saved context.
-     * We should be careful about this function:
-     *  a. If the saved stack is equal to or larger than current stack size, 
-     *     then we can't simply overlap current stack from the saved stack.
-     *     since it will screw current stack. 
-     *  b. If the saved stack is smaller than current stacksize, then it can be
-     *     safe to overlap current stack. 
-     * In our implementation, we may utilize a temporary stack to recover the stack.
-     */
-    unsigned long ebp, esp;
-
-    // The offset to the stack bottom.
-    unsigned long espoffset, ebpoffset;
-
-    unsigned long newebp, newesp;
-    unsigned long stackStart;
-    unsigned long offset;
-
-    // Get current esp and ebp
-#if defined(X86_32BIT)
-    asm volatile(
-      "movl %%ebp,%0\n" \
-      "movl %%esp,%1\n" \
-      :"=r"(ebp), "=r"(esp)
-    );
-#else
-    asm volatile(
-      "movq %%rbp,%0\n" \
-      "movq %%rsp, %1\n" \
-      :"=r"(ebp), "=r"(esp)
-    );
-#endif
-
-    // Calculate the offset to stack bottom for ebp and esp register. 
-    // Since we know that we are still using the original stack.
-    espoffset = _stackTop - esp;
-    ebpoffset = _stackTop - ebp;
-
-    // Check whether we can utilize the temporary stack.
-    if(espoffset > xdefines::TEMP_STACK_SIZE) {
-      PRINF("Now esp %lx ebp %lx, stackbottom %lx\n", esp, ebp, _stackTop);
-      PRINF("Now we can't use the reserved temporary stack, espoffset %lx temporary stack size %lx\n", espoffset, xdefines::TEMP_STACK_SIZE);
-      // FIXME: we might use some malloced memory, but not now.
-      abort();
-    }
-
-    // Calculate the new ebp and esp registers. 
-    // We will set ebp to the bottom of temporary stack. 
-    newebp = _tempStackBottom - ebpoffset;
-    newesp = _tempStackBottom - espoffset;
-
-    // Copy the existing stack to the temporary stack.
-    // Otherwise, we can not locate those global variables???
-    memcpy((void *)newesp, (void *)esp, espoffset);
-
-    // Switch the stack manually. 
-    // It is important to switch in this place (not using a function call), otherwise, the lowest
-    // level of frame will be poped out and the stack will return back to the original one
-    // Then techniquely we cann't switch successfully. 
-    // What we want is that new frames are using the new stack, but we will recover
-    // the stack in the same function later to void problems!!!
-#if defined(X86_32BIT)
-    asm volatile(
-      // Set ebp and esp to new pointer
-      "movl %0, %%ebp\n"
-      "movl %1, %%esp\n"
-      : : "r" (newebp), "r" (newesp)
-    );
-#else
-    asm volatile(
-      // Set ebp and esp to new pointer
-      "movq %0,%%rbp\n"
-      "movq %1,%%rsp\n"
-      : : "r" (newebp), "r" (newesp)
-    );
-#endif 
-
-    // The recovery of stack are safe no matter how large of the original stack
-    memcpy(_pstackTopSaved, &_stack, _stackSize);
-    
-    if(stop) {
-      while(1) ;
-    }
-
-    // After recovery of the stack, we can call setcontext to switch to original stack. 
-    setcontext (&_context);
-  }
-#endif
-
-  // Now we need to save the context
-  inline void saveContext() {
-    size_t size;
-    // PRINF("SAVECONTEXT: Current %p _privateTop %p at %p _backup %p\n", getpid(), _privateTop,
-    // &_privateTop, _backup);
-    //    PRINF("saveContext nownow!!!!!!\n");
-    // Save the stack at first.
-    _privateStart = &size;
-    size = size_t((intptr_t)_privateTop - (intptr_t)_privateStart);
-    _backupSize = size;
-
-    if(size >= _stackSize) {
-      PRWRN("Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n", size,
-            _privateTop, _privateStart, _stackSize);
-      Real::exit(-1);
-    }
-    memcpy(_backup, _privateStart, size);
-    // We are trying to save context at first
-    getcontext(&_context);
-  }
-
-  // We already have context. How we can save this context.
-  inline void saveSpecifiedContext(ucontext_t* context) {
-    // Find out the esp pointer.
-    size_t size;
-
-    // Save the stack at first.
-    _privateStart = (void*)getStackPointer(context);
-    size = size_t((intptr_t)_privateTop - (intptr_t)_privateStart);
-    _backupSize = size;
-
-    if(size >= _stackSize) {
-      PRWRN("Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n", size,
-            _privateTop, _privateStart, _stackSize);
-      abort();
-    }
-
-    memcpy(_backup, _privateStart, size);
-
-    // We are trying to save context at first
-    memcpy(&_context, context, sizeof(ucontext_t));
-  }
-
-  /* Finish the following tasks here:
-    a. Change current stack to the stack of newContext. We have to utilize
-       a temporary stack to host current stack.
-    b. Copy the stack from newContext to current stack.
-    c. Switch back from the temporary stack to current stack.
-    d. Copy the stack and context from newContext to oldContext.
-    f. setcontext to the context of newContext.
-   */
-  inline static void resetContexts(xcontext* oldContext, xcontext* newContext) {
-    // We can only do this when these two contexts are for the same thread.
-    assert(oldContext->getPrivateTop() == newContext->getPrivateTop());
-
-    // We will backup the stack and context from newContext at first.
-    oldContext->backupStackAndContext(newContext);
-
-    restoreContext(oldContext, newContext);
-  }
-
-  // Copy the stack from newContext to oldContext.
-  void backupStackAndContext(xcontext* context) {
-    // We first backup the context.
-    _privateStart = context->getPrivateStart();
-    _backupSize = context->getBackupSize();
-
-    memcpy(_backup, context->getBackupStart(), _backupSize);
-
-    // Now we will backup the context.
-    memcpy(&_context, context->getContext(), sizeof(ucontext_t));
-  }
-
-  static void rollbackInsideSignalHandler(ucontext_t* context, xcontext* oldContext) {
-    // We first rollback the stack.
-		// Since the thread is inside the context of signal handler, we can simply 
-		// recover the stack by copying, no need to worry about the correctness
-    memcpy(oldContext->getPrivateStart(), oldContext->getBackupStart(),
-           oldContext->getBackupSize());
-
-    memcpy(context, oldContext->getContext(), sizeof(ucontext_t));
-  }
-
-  // Restore context from specified context.
-  /* Finish the following tasks here:
-    a. Change current stack to the stack of newContext. We have to utilize
-       a temporary stack to host current stack.
-    b. Copy the stack from current context to current stack.
-    c. setcontext to the context of newContext.
-   */
-  inline static void restoreContext(xcontext* oldContext, xcontext* newContext) {
-    // We can only do this when these two contexts are for the same thread.
-    assert(oldContext->getPrivateTop() == newContext->getPrivateTop());
-
-    // Now we can mess with newContext.
-    unsigned long ebp, esp;
-
-    // The offset to the stack bottom.
-    unsigned long espoffset, ebpoffset;
-    unsigned long stackTop, newStackTop;
-    unsigned long newebp, newesp;
-// Get current esp and ebp
-#if defined(X86_32BIT)
-    asm volatile("movl %%ebp,%0\n"
-                 "movl %%esp,%1\n"
-                 : "=r"(ebp), "=r"(esp));
-#else
-    asm volatile("movq %%rbp,%0\n"
-                 "movq %%rsp, %1\n"
-                 : "=r"(ebp), "=r"(esp));
-#endif
-
-    // Calculate the offset to stack bottom for ebp and esp register.
-    // Since we know that we are still using the original stack.
-    stackTop = (unsigned long)newContext->getPrivateTop();
-    espoffset = stackTop - esp;
-    ebpoffset = stackTop - ebp;
-
-    REQUIRE(espoffset <= xdefines::TEMP_STACK_SIZE, "Temporary stack exhausted");
-
-    // Calculate the new ebp and esp registers.
-    // We will set ebp to the bottom of temporary stack.
-    newStackTop = (intptr_t)newContext->getBackupStart() + newContext->getStackSize();
-    newebp = newStackTop - ebpoffset;
-    newesp = newStackTop - espoffset;
-
-    // Copy the existing stack to the temporary stack.
-    // Otherwise, we can not locate those global variables???
-    memcpy((void*)newesp, (void*)esp, espoffset);
-
-// Switch the stack manually.
-// It is important to switch in this place (not using a function call), otherwise, the lowest
-// level of frame will be poped out and the stack will return back to the original one
-// Then techniquely we cann't switch successfully.
-// What we want is that new frames are using the new stack, but we will recover
-// the stack in the same function later to void problems!!!
-#if defined(X86_32BIT)
-    asm volatile(
-        // Set ebp and esp to new pointer
-        "movl %0, %%ebp\n"
-        "movl %1, %%esp\n"
-        :
-        : "r"(newebp), "r"(newesp));
-#else
-    asm volatile(
-        // Set ebp and esp to new pointer
-        "movq %0,%%rbp\n"
-        "movq %1,%%rsp\n"
-        :
-        : "r"(newebp), "r"(newesp));
-#endif
-
-    // PRINF("________RESTORECONTEX___________at line %d\n", __LINE__);
-    // Now we will recover the stack from the saved oldContext.
-    memcpy(oldContext->getPrivateStart(), oldContext->getBackupStart(),
-           oldContext->getBackupSize());
-
-    PRINF("Thread %p is calling actual setcontext", (void*)pthread_self());
-    // After recovery of the stack, we can call setcontext to switch to original stack.
-    setcontext(oldContext->getContext());
-  }
+  void saveCurrent();
+  void save(ucontext_t *context);
+  void rollback();
+  void rollbackInHandler(ucontext_t *context);
 
   void* getStackTop() { return _privateTop; }
 
@@ -294,26 +43,15 @@ private:
   ucontext_t* getContext() { return &_context; }
 
   void* getPrivateStart() { return _privateStart; }
-
   void* getPrivateTop() { return _privateTop; }
-
   size_t getBackupSize() { return _backupSize; }
-
   size_t getStackSize() { return _stackSize; }
-
   void* getBackupStart() { return _backup; }
-  // How to get ESP/RSP from the specified context.
-  unsigned long getStackPointer(ucontext* context) {
-#ifndef X86_32BIT
-    return context->uc_mcontext.gregs[REG_RSP];
-#else
-    return context->uc_mcontext.gregs[REG_ESP];
-#endif
-  }
 
-  /// The saved registers, etc.
+  /// Saved registers, including the IP, SP, general purpose and floating point.
   ucontext_t _context;
-  void* _backup; // Where to _backup those thread private information.
+
+  void* _backup; // Where to _backup the thread private information.
   void* _privateStart;
   void* _privateTop;
   size_t _stackSize;

--- a/include/xdefines.hh
+++ b/include/xdefines.hh
@@ -6,8 +6,10 @@
 
 #ifdef X86_32BIT
 #define REG_IP REG_EIP
+#define REG_SP REG_ESP
 #else
 #define REG_IP REG_RIP
+#define REG_SP REG_RSP
 #endif
 
 #include "list.hh"

--- a/source/rollback_amd64.s
+++ b/source/rollback_amd64.s
@@ -1,0 +1,40 @@
+.globl __dt_rollback_ctx
+.type __dt_rollback_ctx,@function
+__dt_rollback_ctx:
+	push %rbp
+	mov %rsp, %rbp
+
+	// hold onto 4th arg (ucontext_t *)
+	mov %rcx, %r8
+
+	// musl's memcpy - after this sequence the stack has been
+	// restored but the current values of RBP and RSP may point
+	// into the middle of this region - they MUST be restored by us.
+	mov %rdi,%rax
+	cmp $8,%rdx
+	jc 1f
+	test $7,%edi
+	jz 1f
+2:	movsb
+	dec %rdx
+	test $7,%edi
+	jnz 2b
+1:	mov %rdx,%rcx
+	shr $3,%rcx
+	rep
+	movsq
+	and $7,%edx
+	jz 1f
+2:	movsb
+	dec %edx
+	jnz 2b
+
+	// restore the stack + base pointers - we can't simply jmp
+	// to setcontext (to avoid the call instruction pushing rip
+	// onto the stack) as setcontext requires the stack itself.
+1:	mov 160(%r8), %rsp // (ucontext_t *)->uc_mcontext.gregs[REG_RSP]
+	mov 120(%r8), %rbp // (ucontext_t *)->uc_mcontext.gregs[REG_RBP]
+
+	// now call setcontext with the (ucontext_t *) as its only arg
+	mov %r8, %rdi
+	callq setcontext@PLT

--- a/source/xcontext.cpp
+++ b/source/xcontext.cpp
@@ -1,0 +1,95 @@
+/**
+ * @class xcontext
+ * @brief User context to support the rollback mechanism.
+ *
+ * @author Tongping Liu <http://www.cs.umass.edu/~tonyliu>
+ */
+
+#include "xcontext.hh"
+
+// these functions are defined in assembly so that they can safely
+// swap the stack underneath themselves
+extern "C" {
+  void __dt_rollback_ctx(void *dst, void *src, size_t len, ucontext_t *ctx);
+}
+
+#define PAGE_SIZE 4096
+#define PAGE_MASK (PAGE_SIZE-1)
+#define PAGE_ALIGN(x) (((intptr_t)(x) + (intptr_t)(PAGE_MASK)) & ~PAGE_MASK)
+#define PAGE_ALIGN_DOWN(x) PAGE_ALIGN(x) - PAGE_SIZE
+
+static intptr_t getStackPointer(ucontext* uctx) {
+  return uctx->uc_mcontext.gregs[REG_SP];
+}
+
+void xcontext::save(ucontext_t *uctx) {
+  intptr_t sp;
+  intptr_t stackBottom;
+  size_t size;
+
+  sp = getStackPointer(uctx);
+  stackBottom = PAGE_ALIGN_DOWN(sp);
+
+  _privateStart = (void *)stackBottom;
+  size = (intptr_t)_privateTop - stackBottom;
+  _backupSize = size;
+
+  REQUIRE(size < _stackSize,
+          "Wrong. Current stack size (%zx = %p - %p) is larger than total size (%zx)\n",
+          size, _privateTop, _privateStart, _stackSize);
+
+  memcpy(_backup, _privateStart, size);
+
+  // We are trying to save context at first
+  memcpy(&_context, uctx, sizeof(ucontext_t));
+}
+
+void xcontext::saveCurrent() {
+  intptr_t sp;
+  intptr_t stackBottom;
+  size_t size;
+
+#if defined(X86_32BIT)
+  asm volatile(
+    // directly grab esp
+    "movl %%esp, %0\n"
+    : "=r"(sp));
+#else
+  asm volatile(
+    // directly grab rsp
+    "movq %%rsp, %0\n"
+    : "=r"(sp));
+#endif
+
+  stackBottom = PAGE_ALIGN_DOWN(sp);
+
+  _privateStart = (void *)stackBottom;
+  size = (intptr_t)_privateTop - stackBottom;
+  _backupSize = size;
+
+  PRINF("Backup size: %zu/%zu", size, _stackSize);
+
+  REQUIRE(size < _stackSize,
+          "Stack too large. top:%p sp:%p PAGE_ALIGN(sp):%p size:%zu",
+          _privateTop, (void *)sp, (void *)stackBottom, size);
+
+  memcpy(_backup, _privateStart, size);
+  getcontext(&_context);
+}
+
+void xcontext::rollback() {
+  // call an arch-specific routine to safely copy the stack under us
+  // (requires memcpy w/o using the stack, something I don't think we
+  // can guarantee in C) and call setcontext
+  __dt_rollback_ctx(_privateStart, _backup, _backupSize, &_context);
+}
+
+// perform a rollback while in the signal handler - this ucontext_t is
+// passed back to the kernel on return from the signal handler and
+// execution resumes there.  Additionally, SIGUSR2 is masked while the
+// handler is running so we don't have to worry about receiving a
+// signal in the middle of this method.
+void xcontext::rollbackInHandler(ucontext_t* kctx) {
+  memcpy(_privateStart, _backup, _backupSize);
+  memcpy(kctx, &_context, sizeof(_context));
+}

--- a/source/xrun.cpp
+++ b/source/xrun.cpp
@@ -262,8 +262,8 @@ void jumpToFunction(ucontext_t* cxt, unsigned long funcaddr) {
 
   // Check what is the current phase
   if(global_isEpochBegin()) {
- 		// Current thread is going to enter a new phase
-    xthread::getInstance().saveSpecifiedContext((ucontext_t*)context);
+    // Current thread is going to enter a new phase
+    xthread::getInstance().saveContext((ucontext_t*)context);
     // NOTE: we do not need to reset contexts if we are still inside the signal handleer
     // since the exiting from signal handler can do this automatically.
   } else {


### PR DESCRIPTION
A thread now only requires a single xcontext - stack swapping is done
by an assembly routine that safely copies the backup under the current
stack and calls setcontext to restore registers and jump to the saved
IP.

Additionally, moving a lot of xcontext into a CPP file made
breakpointing + inspecting what was going on a lot easier.

Finally, the xcontext API was somewhat simplified - it now exposes 4
main functions: save, saveContext (used from sighandler), rollback,
rollbackInHandler (used from sighandler).