### PR TITLE
write(2) always ends epoch

### DIFF
--- a/include/syscalls.hh
+++ b/include/syscalls.hh
@@ -141,14 +141,11 @@ public:
   ssize_t write(int fd, const void* buf, size_t count) {
     ssize_t ret;
 
-    // Check whether this fd is not a socketid.
-    if(_fops.checkPermission(fd)) {
-      ret = Real::write(fd, buf, count);
-    } else {
-      epochEnd();
-      ret = Real::write(fd, buf, count);
-      epochBegin();
-    }
+    // writes always need to end an epoch, otherwise we could end up
+    // with double-writes if we rollback.
+    epochEnd();
+    ret = Real::write(fd, buf, count);
+    epochBegin();
 
     return ret;
   }

--- a/source/libdoubletake.cpp
+++ b/source/libdoubletake.cpp
@@ -451,10 +451,9 @@ extern "C" {
   }
 
   ssize_t write(int fd, const void* buf, size_t count) {
-    if(!initialized || fd == 1 || fd == 2) {
+    if(!initialized) {
       return Real::write(fd, buf, count);
     } else {
-      //  //fprintf(stderr, " write in doubletake at %d\n", __LINE__);
       return syscalls::getInstance().write(fd, buf, count);
     }
   }

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include "log.hh"
+#include "real.hh"
 
 #define NORMAL_CYAN "\033[36m"
 #define NORMAL_MAGENTA "\033[35m"
@@ -71,7 +72,7 @@ void doubletake::logf(const char *file, int line, int level, const char *fmt, ..
   ::vsnprintf(tbuf, LOG_SIZE, fmtbuf, args);
   va_end(args);
 
-  write(OUTFD, tbuf, strlen(tbuf));
+  Real::write(OUTFD, tbuf, strlen(tbuf));
 }
 
 void doubletake::printf(const char *fmt, ...) {
@@ -86,7 +87,7 @@ void doubletake::printf(const char *fmt, ...) {
   ::vsnprintf(tbuf, LOG_SIZE, fmtbuf, args);
   va_end(args);
 
-  write(OUTFD, tbuf, strlen(tbuf));
+  Real::write(OUTFD, tbuf, strlen(tbuf));
 }
 
 void doubletake::fatalf(const char *file, int line, const char *fmt, ...) {


### PR DESCRIPTION
This partially addresses #6.

Without this, we can end up double-writing to files if we call write()
during the same epoch a file is opened in, like:

```
#include <stdio.h>
#include <stdlib.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <unistd.h>
#include <string.h>

#define USED(v) ((void)(v))

int main(int argc, char** argv) {
  int* p = (int*)malloc(sizeof(int));
  *p = 123;
  printf("Hello use after free\n");
  int fd = open("/tmp/append-test", O_CREAT|O_WRONLY|O_APPEND, S_IRWXU|S_IRWXG);
  write(fd, "write1\n", strlen("write1\n"));
  free(p);
  for (int i = 0; i < 1000; i++) {
    volatile int q = 1.0 * 1.0;
    USED(q);
  }
  *p = 456;
  return 0;
}
```

However, printf still results in messages being printed twice, like:
`printf("Hello use after free\n");`.  I'm not sure why this is - maybe
the internal buffering of printf?  But shouldn't that be reset/cleared
when we rollback?
